### PR TITLE
fix: 修复组件图标不正确的问题

### DIFF
--- a/Controls/Components/DecibelComponent.axaml.cs
+++ b/Controls/Components/DecibelComponent.axaml.cs
@@ -14,7 +14,7 @@ namespace Decibel_Monitor.Controls.Components;
 [ComponentInfo(
     "FFFFFFFF-EEEE-DDDD-CCCC-BBBBBBBBBBBB",
     "分贝值",
-    "\uE9B2",
+    "\uEB88",
     "在主界面上显示麦克风分贝值。"
 )]
 public partial class DecibelComponent : ComponentBase<DecibelComponentSettings>, INotifyPropertyChanged, IDisposable


### PR DESCRIPTION
原状：
<img width="462" height="321" alt="image" src="https://github.com/user-attachments/assets/d65f4e79-05f2-42fa-b94e-a5a1c731e45f" />


**修改后效果：**
<img width="451" height="262" alt="image" src="https://github.com/user-attachments/assets/dbf3376f-07db-423c-9bb0-17c7ff6cb61f" />

更新你的插件时别忘了更新manifest.yml里的插件版本号哦